### PR TITLE
Added IsoFallbackTranslationsLoader

### DIFF
--- a/scripts/retrievers/IsoFallbackTranslationsLoader
+++ b/scripts/retrievers/IsoFallbackTranslationsLoader
@@ -1,0 +1,49 @@
+import { Dictionary } from "ninjagoat";
+import { injectable, inject } from "inversify";
+import { ITranslationsConfig, ITranslationsLoader } from "ninjagoat-translations";
+import { HttpClient, IHttpClient } from "ninjagoat";
+
+@injectable()
+export class IsoFallbackTranslationsLoader implements ITranslationsLoader {
+    constructor(
+        @inject("HttpClient") private httpClient: IHttpClient,
+        @inject("ITranslationsConfig") private config: ITranslationsConfig) {
+    }
+
+    load(language: string): Promise<Dictionary<string>> {
+        return new Promise((resolve, reject) => {
+            this.httpClient
+                .get(`${this.config.endpoint}/${language}.json`)
+                .map(response => JSON.parse(response.response))
+                .subscribe(
+                data => {
+                    resolve(data);
+                },
+                ex => {
+                    if (!language) {
+                        return resolve(this.load("en"));
+                    }
+
+                    // checks if the requested language contains the country-code i.e. => fr-BE (french-BELGIUM)
+                    if (language.indexOf("-") > 0) {
+                        // try to fallback to more general language (by removing country-code), i.e. => fr (french)
+                        let genLang = language.split("-")[0];
+                        return resolve(this.load(genLang));
+                    }
+
+                    if (language == "en") {
+                        // if we already falled back to default language (en), then we must reject the promise...
+                        // there is no language available...
+                        reject("no language available");
+                        return;
+                    }
+
+                    // fallback to default language (en)
+                    // en
+                    return resolve(this.load("en"));
+                });
+        });
+    }
+}
+
+export default IsoFallbackTranslationsLoader;


### PR DESCRIPTION
This loader takes in input a language + country code and applies the following fallback rules in case of loading failure:
- tries to load the language + country (i.e. "fr-BE")
- tries to load the language (i.e. "fr")
- tries to load the default language "en"

Language code and Country code must be separated by '-' character

The common convention is to use: 
ISO 639-1 for the language code
ISO 3166-1 alpha 2 for the country code.
In any case, clients can choose freely the language code / country code standard, the only requirement for the loader is the usage of the '-' separator 
